### PR TITLE
Update PrimitiveCreateContextBase.cs

### DIFF
--- a/Runtime/Scripts/PrimitiveCreateContextBase.cs
+++ b/Runtime/Scripts/PrimitiveCreateContextBase.cs
@@ -44,7 +44,7 @@ namespace GLTFast
 
         public void SetMaterial(int subMesh, int materialIndex)
         {
-            if(subMesh < materialIndex)
+            if(m_Materials.Count < subMesh)
                 m_Materials[subMesh] = materialIndex;
         }
 


### PR DESCRIPTION
When the model encoded in draco is fualt, we need to check if the materials array is not out of bounds when assigning the materials