### PR TITLE
Update GltfImport.cs

### DIFF
--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -393,9 +393,9 @@ namespace GLTFast
         {
             var firstBytes = new byte[4];
 
-#if UNITY_2021_3_OR_NEWER && NET_STANDARD_2_1
-            await using
-#endif
+// #if UNITY_2021_3_OR_NEWER && NET_STANDARD_2_1
+//             await using
+// #endif
             var fs = new FileStream(localPath, FileMode.Open, FileAccess.Read);
             var bytesRead = await fs.ReadAsync(firstBytes, 0, firstBytes.Length, cancellationToken);
 


### PR DESCRIPTION
Commented this code in order to avoid an error in Unity lower than 2022.3  PS: We might need to uncomment this code if we updated the unity version